### PR TITLE
Migração Condicional na criação do campo geo

### DIFF
--- a/municipios/migrations/0001_initial.py
+++ b/municipios/migrations/0001_initial.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-
 from django.db import models, migrations
+from django.conf import settings
 
 
 class Migration(migrations.Migration):
@@ -34,3 +34,24 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(to='municipios.UF'),
         ),
     ]
+
+    if settings.MUNICIPIOS_GEO:
+        SRID = getattr(settings, 'MUNICIPIOS_SRID', 900913)
+        import django.contrib.gis.db.models.fields
+        operations.extend([
+            migrations.AddField(
+                model_name='municipio',
+                name='geom',
+                field=django.contrib.gis.db.models.fields.MultiPolygonField(blank=True, null=True, srid=SRID)
+            ),
+            migrations.AddField(
+                model_name='municipio',
+                name='sede',
+                field=django.contrib.gis.db.models.fields.PointField(blank=True, null=True, srid=SRID)
+            ),
+            migrations.AddField(
+                model_name='uf',
+                name='geom',
+                field=django.contrib.gis.db.models.fields.MultiPolygonField(blank=True, null=True, srid=SRID)
+            ),
+        ])

--- a/municipios/migrations/0001_initial.py
+++ b/municipios/migrations/0001_initial.py
@@ -35,7 +35,7 @@ class Migration(migrations.Migration):
         ),
     ]
 
-    if settings.MUNICIPIOS_GEO:
+    if getattr(settings, 'MUNICIPIOS_GEO', False):
         SRID = getattr(settings, 'MUNICIPIOS_SRID', 900913)
         import django.contrib.gis.db.models.fields
         operations.extend([


### PR DESCRIPTION
As migrações do suporte para django > 1.7 não consideravam os settings ```MUNICIPIOS_GEO``` nem ```MUNICIPIOS_SRID```.

A mudança leva isto em consideração e faz um ```extend``` na lista de operações, caso as settings estejam configuradas corretamente.