### PR TITLE
ref urls: Support for string view arguments to url() is deprecated an…

### DIFF
--- a/municipios/forms.py
+++ b/municipios/forms.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 from django import forms
 
-from widgets import SelectMunicipioWidget
+try:
+    from widgets import SelectMunicipioWidget
+except:
+    # python 3.5.2 django1.9
+    from municipios.widgets import SelectMunicipioWidget
 
 
 class FormMunicipio(forms.Form):

--- a/municipios/urls.py
+++ b/municipios/urls.py
@@ -1,13 +1,32 @@
+from django import VERSION
+
+# django 1.9 or >
+um_nove_ou_maior = all([VERSION[0] == 1, VERSION[1] >= 9])
+
 try:
     from django.conf.urls import patterns, url
 except:
-    from django.conf.urls.defaults import patterns, url
+    from django.conf.urls.defaults import url
 
-
-urlpatterns = patterns(
-    'municipios.views',
-    url(r'^$', 'base_url_js', name='municipios-base-url'),
-    url(r'^base_url.js$', 'base_url_js', name='municipios-base-url-js'),
-    url(r'^ajax/municipios/(?P<uf>\w\w)/(?P<app_label>\w+)/(?P<object_name>\w+)/$', 'municipios_ajax', name='municipios-ajax'),
-    url(r'^teste/', 'teste', name='municipios-teste'),
-)
+if um_nove_ou_maior:
+    # não compativel com django 2.0 
+    from municipios.views import (
+        base_url_js,
+        municipios_ajax,
+        teste,
+        )
+    urlpatterns = [
+        url(r'^$', base_url_js, name='municipios-base-url'),
+        url(r'^base_url.js$', base_url_js, name='municipios-base-url-js'),
+        url(r'^ajax/municipios/(?P<uf>\w\w)/$', municipios_ajax, name='municipios-ajax'),
+        url(r'^teste/', teste, name='municipios-teste'),
+    ]
+else:
+    # is deprecated and will be removed in Django 1.10
+    urlpatterns = patterns(
+        'municipios.views',
+        url(r'^$', 'base_url_js', name='municipios-base-url'),
+        url(r'^base_url.js$', 'base_url_js', name='municipios-base-url-js'),
+        url(r'^ajax/municipios/(?P<uf>\w\w)/(?P<app_label>\w+)/(?P<object_name>\w+)/$', 'municipios_ajax', name='municipios-ajax'),
+        url(r'^teste/', 'teste', name='municipios-teste'),
+    )

--- a/municipios/views.py
+++ b/municipios/views.py
@@ -6,8 +6,11 @@ from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.apps import apps
 
-from forms import FormMunicipio
-
+try:
+    from forms import FormMunicipio
+except:
+    # python 3.5.2 django1.9
+    from municipios.forms import FormMunicipio
 
 def base_url_js(request):
     return HttpResponse(u"var __municipios_base_url__ = '%s';" % reverse('municipios-base-url'))


### PR DESCRIPTION
 Support for string view arguments to url() is deprecated and will be removed in Django 1.10; view e forms: altera o path de importação, ex: de 'from forms import' para 'from municipios.forms import'