### PR TITLE
ref #18  urls: Support for string view arguments to url() is deprecated an…

### DIFF
--- a/municipios/forms.py
+++ b/municipios/forms.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 from django import forms
 
-from widgets import SelectMunicipioWidget
+try:
+    from widgets import SelectMunicipioWidget
+except:
+    # python 3.5.2 django1.9
+    from municipios.widgets import SelectMunicipioWidget
 
 
 class FormMunicipio(forms.Form):

--- a/municipios/urls.py
+++ b/municipios/urls.py
@@ -1,32 +1,13 @@
-from django import VERSION
-
-# django 1.9 or >
-um_nove_ou_maior = all([VERSION[0] == 1, VERSION[1] >= 9])
-
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except:
     from django.conf.urls.defaults import url
 
-if um_nove_ou_maior:
-    # não compativel com django 2.0 
-    from municipios.views import (
-        base_url_js,
-        municipios_ajax,
-        teste,
-        )
-    urlpatterns = [
-        url(r'^$', base_url_js, name='municipios-base-url'),
-        url(r'^base_url.js$', base_url_js, name='municipios-base-url-js'),
-        url(r'^ajax/municipios/(?P<uf>\w\w)/$', municipios_ajax, name='municipios-ajax'),
-        url(r'^teste/', teste, name='municipios-teste'),
-    ]
-else:
-    # is deprecated and will be removed in Django 1.10
-    urlpatterns = patterns(
-        'municipios.views',
-        url(r'^$', 'base_url_js', name='municipios-base-url'),
-        url(r'^base_url.js$', 'base_url_js', name='municipios-base-url-js'),
-        url(r'^ajax/municipios/(?P<uf>\w\w)/(?P<app_label>\w+)/(?P<object_name>\w+)/$', 'municipios_ajax', name='municipios-ajax'),
-        url(r'^teste/', 'teste', name='municipios-teste'),
-    )
+import municipios.views as mviews
+
+urlpatterns = (
+    url(r'^$', mviews.base_url_js, name='municipios-base-url'),
+    url(r'^base_url.js$', mviews.base_url_js, name='municipios-base-url-js'),
+    url(r'^ajax/municipios/(?P<uf>\w\w)/(?P<app_label>\w+)/(?P<object_name>\w+)/$', mviews.municipios_ajax, name='municipios-ajax'),
+    url(r'^teste/', mviews.teste, name='municipios-teste'),
+)

--- a/municipios/urls.py
+++ b/municipios/urls.py
@@ -1,13 +1,32 @@
+from django import VERSION
+
+# django 1.9 or >
+um_nove_ou_maior = all([VERSION[0] == 1, VERSION[1] >= 9])
+
 try:
     from django.conf.urls import patterns, url
 except:
-    from django.conf.urls.defaults import patterns, url
+    from django.conf.urls.defaults import url
 
-
-urlpatterns = patterns(
-    'municipios.views',
-    url(r'^$', 'base_url_js', name='municipios-base-url'),
-    url(r'^base_url.js$', 'base_url_js', name='municipios-base-url-js'),
-    url(r'^ajax/municipios/(?P<uf>\w\w)/(?P<app_label>\w+)/(?P<object_name>\w+)/$', 'municipios_ajax', name='municipios-ajax'),
-    url(r'^teste/', 'teste', name='municipios-teste'),
-)
+if um_nove_ou_maior:
+    # não compativel com django 2.0 
+    from municipios.views import (
+        base_url_js,
+        municipios_ajax,
+        teste,
+        )
+    urlpatterns = [
+        url(r'^$', base_url_js, name='municipios-base-url'),
+        url(r'^base_url.js$', base_url_js, name='municipios-base-url-js'),
+        url(r'^ajax/municipios/(?P<uf>\w\w)/$', municipios_ajax, name='municipios-ajax'),
+        url(r'^teste/', teste, name='municipios-teste'),
+    ]
+else:
+    # is deprecated and will be removed in Django 1.10
+    urlpatterns = patterns(
+        'municipios.views',
+        url(r'^$', 'base_url_js', name='municipios-base-url'),
+        url(r'^base_url.js$', 'base_url_js', name='municipios-base-url-js'),
+        url(r'^ajax/municipios/(?P<uf>\w\w)/(?P<app_label>\w+)/(?P<object_name>\w+)/$', 'municipios_ajax', name='municipios-ajax'),
+        url(r'^teste/', 'teste', name='municipios-teste'),
+    )

--- a/municipios/views.py
+++ b/municipios/views.py
@@ -6,8 +6,11 @@ from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.apps import apps
 
-from forms import FormMunicipio
-
+try:
+    from forms import FormMunicipio
+except:
+    # python 3.5.2 django1.9
+    from municipios.forms import FormMunicipio
 
 def base_url_js(request):
     return HttpResponse(u"var __municipios_base_url__ = '%s';" % reverse('municipios-base-url'))


### PR DESCRIPTION

Support for string view arguments to url() is deprecated and will be removed in Django 1.10; view e forms: altera o path de importação, ex: de 'from forms import' para 'from municipios.forms import'

testei usando django 1.9 e python 3.5.2

python manage.py check

```
/home/fabiano/.venvs/escolar/lib/python3.5/site-packages/municipios/urls.py:9: RemovedInDjango110Warning: Support for string view arguments to url() is deprecated and will be removed in Django 1.10 (got base_url_js). Pass the callable instead.
  url(r'^$', 'base_url_js', name='municipios-base-url'),

/home/fabiano/.venvs/escolar/lib/python3.5/site-packages/municipios/urls.py:10: RemovedInDjango110Warning: Support for string view arguments to url() is deprecated and will be removed in Django 1.10 (got base_url_js). Pass the callable instead.
  url(r'^base_url.js$', 'base_url_js', name='municipios-base-url-js'),

/home/fabiano/.venvs/escolar/lib/python3.5/site-packages/municipios/urls.py:11: RemovedInDjango110Warning: Support for string view arguments to url() is deprecated and will be removed in Django 1.10 (got municipios_ajax). Pass the callable instead.
  url(r'^ajax/municipios/(?P<uf>\w\w)/$', 'municipios_ajax', name='municipios-ajax'),

/home/fabiano/.venvs/escolar/lib/python3.5/site-packages/municipios/urls.py:12: RemovedInDjango110Warning: Support for string view arguments to url() is deprecated and will be removed in Django 1.10 (got teste). Pass the callable instead.
  url(r'^teste/', 'teste', name='municipios-teste'),

/home/fabiano/.venvs/escolar/lib/python3.5/site-packages/municipios/urls.py:12: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  url(r'^teste/', 'teste', name='municipios-teste'),
```
depois das alterações:

```
python manage.py check
System check identified no issues (0 silenced).

```